### PR TITLE
fix: send Authorization Bearer header for Gemini's OpenAI-compatible …

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,28 @@ curl -X POST "http://localhost:8990/gemini/models/gemini-2.5-flash:generateConte
   }'
 ```
 
-**Note**: Replace `your-access-key` with your provider's ACCESS_KEY if configured. If no ACCESS_KEY is set for the provider, you can omit the `[ACCESS_KEY:...]` parameter entirely.
+ **Note**: Replace `your-access-key` with your provider's ACCESS_KEY if configured. If no ACCESS_KEY is set for the provider, you can omit the `[ACCESS_KEY:...]` parameter entirely.
+
+### Calling Gemini's OpenAI-Compatible Endpoint
+
+Gemini also exposes an OpenAI-compatible surface at `/v1beta/openai/chat/completions`, which authenticates with an `Authorization: Bearer` header instead of the `key` query param / `x-goog-api-key` header used by native Gemini endpoints (e.g. `:generateContent`). A `gemini`-type provider automatically detects this and switches to `Authorization: Bearer` whenever the request path contains `/openai/` or `/chat/completions`, so you can hit it either through a native provider:
+
+```bash
+curl -X POST "http://localhost:8990/gemini/openai/chat/completions" \
+  -H "x-goog-api-key: [STATUS_CODES:429]" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gemini-2.5-flash",
+    "messages": [
+      { "role": "user", "content": "Hello! Please say hello back." 
+      }
+    ]
+  }'
+```
+
+or by pointing `GEMINI_<PROVIDER>_BASE_URL` at `https://generativelanguage.googleapis.com/v1beta/openai` and calling `/chat/completions` directly.
+
+## File Logging
 
 ## File Logging
 

--- a/src/geminiClient.js
+++ b/src/geminiClient.js
@@ -1,4 +1,4 @@
-const https = require('https');
+ const https = require('https');
 const { URL } = require('url');
 
 class GeminiClient {
@@ -155,7 +155,17 @@ class GeminiClient {
       ...headers
     };
 
-    if (useHeader) {
+    // Google's OpenAI-compatibility layer (paths like /openai/chat/completions,
+    // or a base URL that already points at .../v1beta/openai) does NOT accept
+    // the native `key` query param or `x-goog-api-key` header - it requires a
+    // standard `Authorization: Bearer <key>` header, same as OpenAI itself.
+    // Without this, requests routed to that surface fail with a missing/invalid
+    // authorization error even though a valid Gemini key was supplied.
+    if (this.isOpenAICompatiblePath(path) || this.isOpenAICompatiblePath(this.baseUrl)) {
+      if (!headers || !headers.authorization) {
+        finalHeaders['Authorization'] = `Bearer ${apiKey}`;
+      }
+    } else if (useHeader) {
       finalHeaders['x-goog-api-key'] = apiKey;
     } else {
       url.searchParams.append('key', apiKey);
@@ -254,6 +264,21 @@ class GeminiClient {
   maskApiKey(key) {
     if (!key || key.length < 8) return '***';
     return key.substring(0, 4) + '...' + key.substring(key.length - 4);
+  }
+
+  /**
+   * Detects whether a path or base URL targets Gemini's OpenAI-compatibility
+   * surface (e.g. "/openai/chat/completions", ".../v1beta/openai") rather
+   * than the native Gemini API (e.g. "/v1beta/models/gemini-pro:generateContent").
+   * That surface authenticates like OpenAI - via an Authorization: Bearer
+   * header - not via the `key` query param or `x-goog-api-key` header used
+   * by native Gemini endpoints.
+   * @param {string} value A path or URL to inspect
+   * @returns {boolean}
+   */
+  isOpenAICompatiblePath(value) {
+    if (!value) return false;
+    return /\/openai(\/|$)/i.test(value) || /\/chat\/completions(\?|$)/i.test(value);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #6 — requests to Gemini's OpenAI-compatible endpoint
(`/openai/chat/completions`) were failing with a missing
Authorization header.

## Root Cause

`GeminiClient` always authenticated using Gemini's native scheme —
either the `key` query param or the `x-goog-api-key` header. That
works for native endpoints (e.g. `:generateContent`), but Gemini's
OpenAI-compatibility surface at `/v1beta/openai/chat/completions`
authenticates like OpenAI does: via a standard
`Authorization: Bearer <key>` header. Since that header was never
sent, calls to the OpenAI-compatible route failed as unauthenticated
even with a valid key configured.

## Fix

- Added `GeminiClient.isOpenAICompatiblePath()` to detect when a
  request path or base URL targets the OpenAI-compatible surface
  (`/openai/...` or `/chat/completions`).
- `_buildRequestOptions()` now sends `Authorization: Bearer <key>`
  for those requests instead of the `key` query param.
- Native Gemini endpoint auth (query param / `x-goog-api-key`) is
  unchanged for all other paths.
- An `Authorization` header the caller already set is left as-is.
- Documented the OpenAI-compatible endpoint and its auth behavior
  in the README.

## Testing

Verified manually with `_buildRequestOptions()` across 4 cases:
1. Native Gemini path → unchanged, still uses `key` query param
2. `/openai/chat/completions` path → now sends `Authorization: Bearer`
3. Base URL already ending in `.../v1beta/openai` + `/chat/completions` path → sends `Authorization: Bearer`
4. Caller-supplied `Authorization` header → preserved, not overwritten

No existing behavior changes for native Gemini calls.