### PR TITLE
Add unit tests for KeyRotator, GeminiClient, OpenAIClient

### DIFF
--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,0 +1,16 @@
+/**
+ * Runs all test-*.js files in this directory using Node's built-in test runner.
+ * Usage: npm test  (or: node tests/run-tests.js)
+ */
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const testDir = __dirname;
+const files = fs
+  .readdirSync(testDir)
+  .filter((f) => f.startsWith('test-') && f.endsWith('.js'))
+  .map((f) => path.join(testDir, f));
+
+const result = spawnSync(process.execPath, ['--test', ...files], { stdio: 'inherit' });
+process.exit(result.status ?? 1);

--- a/tests/test-gemini.js
+++ b/tests/test-gemini.js
@@ -1,0 +1,41 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const GeminiClient = require('../src/geminiClient');
+const KeyRotator = require('../src/keyRotator');
+
+function makeClient() {
+  const rotator = new KeyRotator(['gk1', 'gk2'], 'gemini');
+  return new GeminiClient(rotator, 'https://generativelanguage.googleapis.com');
+}
+
+test('GeminiClient - builds a request URL with the key as a query param by default', () => {
+  const client = makeClient();
+  const options = client._buildRequestOptions('POST', '/v1beta/models/gemini-pro:generateContent', { a: 1 }, {}, 'my-key', false);
+
+  assert.equal(options.hostname, 'generativelanguage.googleapis.com');
+  assert.ok(options.path.startsWith('/v1beta/models/gemini-pro:generateContent'));
+  assert.ok(options.path.includes('key=my-key'));
+  assert.equal(options.headers['x-goog-api-key'], undefined);
+});
+
+test('GeminiClient - builds a request with the key as a header when useHeader is true', () => {
+  const client = makeClient();
+  const options = client._buildRequestOptions('POST', '/v1beta/models/gemini-pro:generateContent', { a: 1 }, {}, 'my-key', true);
+
+  assert.equal(options.headers['x-goog-api-key'], 'my-key');
+  assert.ok(!options.path.includes('key=my-key'));
+});
+
+test('GeminiClient - sets Content-Length only for non-GET requests with a body', () => {
+  const client = makeClient();
+  const withBody = client._buildRequestOptions('POST', '/v1/test', { a: 1 }, {}, 'k', false);
+  const getRequest = client._buildRequestOptions('GET', '/v1/test', null, {}, 'k', false);
+
+  assert.ok(withBody.headers['Content-Length'] > 0);
+  assert.equal(getRequest.headers['Content-Length'], undefined);
+});
+
+test('GeminiClient - maskApiKey hides the middle of a key', () => {
+  const client = makeClient();
+  assert.equal(client.maskApiKey('AIzaSyABCDEFGH1234'), 'AIza...1234');
+});

--- a/tests/test-keyrotator.js
+++ b/tests/test-keyrotator.js
@@ -1,0 +1,124 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const KeyRotator = require('../src/keyRotator');
+
+test('KeyRotator - initializes usage counts for all keys at zero', () => {
+  const rotator = new KeyRotator(['k1', 'k2', 'k3'], 'gemini');
+  const stats = rotator.getKeyUsageStats();
+
+  assert.equal(stats.length, 3);
+  for (const s of stats) {
+    assert.equal(s.usageCount, 0);
+  }
+});
+
+test('KeyRotator - incrementKeyUsage only affects the given key', () => {
+  const rotator = new KeyRotator(['k1', 'k2'], 'gemini');
+  rotator.incrementKeyUsage('k1');
+  rotator.incrementKeyUsage('k1');
+
+  const stats = rotator.getKeyUsageStats();
+  const k1 = stats.find((s) => s.fullKey === 'k1');
+  const k2 = stats.find((s) => s.fullKey === 'k2');
+
+  assert.equal(k1.usageCount, 2);
+  assert.equal(k2.usageCount, 0);
+});
+
+test('KeyRotator - maskApiKey hides the middle of a key', () => {
+  const rotator = new KeyRotator(['sk-abcdefgh1234'], 'gemini');
+  const masked = rotator.maskApiKey('sk-abcdefgh1234');
+
+  assert.equal(masked, 'sk-a...1234');
+  assert.ok(!masked.includes('bcdefgh'));
+});
+
+test('KeyRotator - maskApiKey returns a placeholder for short/empty keys', () => {
+  const rotator = new KeyRotator(['k1'], 'gemini');
+  assert.equal(rotator.maskApiKey(''), '***');
+  assert.equal(rotator.maskApiKey('short'), '***');
+});
+
+test('RequestKeyContext - getNextKey returns every key exactly once', () => {
+  const rotator = new KeyRotator(['k1', 'k2', 'k3'], 'gemini');
+  const ctx = rotator.createRequestContext();
+
+  const seen = new Set();
+  let key;
+  while ((key = ctx.getNextKey()) !== null) {
+    assert.ok(!seen.has(key), `key ${key} returned more than once`);
+    seen.add(key);
+  }
+
+  assert.equal(seen.size, 3);
+  assert.deepEqual([...seen].sort(), ['k1', 'k2', 'k3']);
+});
+
+test('RequestKeyContext - getNextKey returns null once all keys are exhausted', () => {
+  const rotator = new KeyRotator(['k1'], 'gemini');
+  const ctx = rotator.createRequestContext();
+
+  assert.equal(ctx.getNextKey(), 'k1');
+  assert.equal(ctx.getNextKey(), null);
+  assert.equal(ctx.getNextKey(), null);
+});
+
+test('RequestKeyContext - smart shuffle moves the last failed key to the end', () => {
+  const rotator = new KeyRotator(['k1', 'k2', 'k3', 'k4'], 'gemini');
+  rotator.updateLastFailedKey('k2');
+
+  // Run several times since shuffling is randomized - k2 should always land last.
+  for (let i = 0; i < 20; i++) {
+    const ctx = rotator.createRequestContext();
+    assert.equal(ctx.apiKeys[ctx.apiKeys.length - 1], 'k2');
+    assert.equal(ctx.apiKeys.length, 4);
+  }
+});
+
+test('RequestKeyContext - markKeyAsRateLimited tracks rate-limited keys', () => {
+  const rotator = new KeyRotator(['k1', 'k2'], 'gemini');
+  const ctx = rotator.createRequestContext();
+
+  const first = ctx.getNextKey();
+  ctx.markKeyAsRateLimited(first);
+
+  assert.equal(ctx.getLastFailedKey(), first);
+  assert.equal(ctx.allTriedKeysRateLimited(), true);
+});
+
+test('RequestKeyContext - allTriedKeysRateLimited is false if only some keys failed', () => {
+  const rotator = new KeyRotator(['k1', 'k2'], 'gemini');
+  const ctx = rotator.createRequestContext();
+
+  const first = ctx.getNextKey();
+  ctx.markKeyAsRateLimited(first);
+  ctx.getNextKey(); // second key tried but not marked as rate limited
+
+  assert.equal(ctx.allTriedKeysRateLimited(), false);
+});
+
+test('RequestKeyContext - allKeysTried reflects exhaustion correctly', () => {
+  const rotator = new KeyRotator(['k1', 'k2'], 'gemini');
+  const ctx = rotator.createRequestContext();
+
+  assert.equal(ctx.allKeysTried(), false);
+  ctx.getNextKey();
+  assert.equal(ctx.allKeysTried(), false);
+  ctx.getNextKey();
+  assert.equal(ctx.allKeysTried(), true);
+});
+
+test('RequestKeyContext - getStats reports totals correctly', () => {
+  const rotator = new KeyRotator(['k1', 'k2', 'k3'], 'gemini');
+  const ctx = rotator.createRequestContext();
+
+  ctx.getNextKey();
+  const rateLimited = ctx.getNextKey();
+  ctx.markKeyAsRateLimited(rateLimited);
+
+  const stats = ctx.getStats();
+  assert.equal(stats.totalKeys, 3);
+  assert.equal(stats.triedKeys, 2);
+  assert.equal(stats.rateLimitedKeys, 1);
+  assert.equal(stats.hasUntriedKeys, true);
+});

--- a/tests/test-openai.js
+++ b/tests/test-openai.js
@@ -1,0 +1,44 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const OpenAIClient = require('../src/openaiClient');
+const KeyRotator = require('../src/keyRotator');
+
+function makeClient() {
+  const rotator = new KeyRotator(['ok1', 'ok2'], 'openai');
+  return new OpenAIClient(rotator, 'https://api.openai.com');
+}
+
+test('OpenAIClient - adds a Bearer Authorization header by default', () => {
+  const client = makeClient();
+  const options = client._buildRequestOptions('POST', '/v1/chat/completions', { a: 1 }, {}, 'my-key');
+
+  assert.equal(options.headers['Authorization'], 'Bearer my-key');
+  assert.equal(options.hostname, 'api.openai.com');
+});
+
+test('OpenAIClient - does not overwrite an Authorization header already provided', () => {
+  const client = makeClient();
+  const options = client._buildRequestOptions(
+    'POST',
+    '/v1/chat/completions',
+    { a: 1 },
+    { authorization: 'Bearer custom-token' },
+    'my-key'
+  );
+
+  assert.equal(options.headers.authorization, 'Bearer custom-token');
+});
+
+test('OpenAIClient - sets Content-Length only for non-GET requests with a body', () => {
+  const client = makeClient();
+  const withBody = client._buildRequestOptions('POST', '/v1/test', { a: 1 }, {}, 'k');
+  const getRequest = client._buildRequestOptions('GET', '/v1/test', null, {}, 'k');
+
+  assert.ok(withBody.headers['Content-Length'] > 0);
+  assert.equal(getRequest.headers['Content-Length'], undefined);
+});
+
+test('OpenAIClient - maskApiKey hides the middle of a key', () => {
+  const client = makeClient();
+  assert.equal(client.maskApiKey('sk-abcdefgh1234'), 'sk-a...1234');
+});


### PR DESCRIPTION
package.json defines `test`, `test:gemini`, and `test:openai` scripts, 
but the `tests/` directory doesn't exist in the repo — running `npm test` 
currently fails with `MODULE_NOT_FOUND`.

This PR fixes that by adding 19 unit tests covering:
- KeyRotator's smart-shuffle and per-request rotation logic
  (last-failed-key handling, rate-limit tracking, key exhaustion)
- GeminiClient and OpenAIClient's request-building logic
  (URL construction, auth header/query-param handling, key masking)

Uses Node's built-in `node:test` runner — no new dependencies added, 
in line with the project's zero-dependency approach.

All tests pass locally:
tests 19, pass 19, fail 0